### PR TITLE
chore(deps): use commit SHAs instead of tag object SHAs

### DIFF
--- a/.github/workflows/ci-failure-analysis.yml
+++ b/.github/workflows/ci-failure-analysis.yml
@@ -37,7 +37,7 @@ jobs:
 
     steps:
       - name: Analyze failure with Claude
-        uses: anthropics/claude-code-action@098e6be5fa94fd7f5b98b1f1a9b874cb9269e583 # v1.0.29
+        uses: anthropics/claude-code-action@1b8ee3b94104046d71fde52ec3557651ad8c0d71 # v1.0.29
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           prompt: |

--- a/.github/workflows/claude-pr-review.yml
+++ b/.github/workflows/claude-pr-review.yml
@@ -42,7 +42,7 @@ jobs:
         run: npm install -g markdownlint-cli
 
       - name: Review PR with Claude
-        uses: anthropics/claude-code-action@098e6be5fa94fd7f5b98b1f1a9b874cb9269e583 # v1.0.29
+        uses: anthropics/claude-code-action@1b8ee3b94104046d71fde52ec3557651ad8c0d71 # v1.0.29
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           track_progress: true

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -58,7 +58,7 @@ jobs:
 
       - name: Run Claude Code
         id: claude
-        uses: anthropics/claude-code-action@098e6be5fa94fd7f5b98b1f1a9b874cb9269e583 # v1.0.29
+        uses: anthropics/claude-code-action@1b8ee3b94104046d71fde52ec3557651ad8c0d71 # v1.0.29
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           use_commit_signing: true

--- a/.github/workflows/plugin-validation.yml
+++ b/.github/workflows/plugin-validation.yml
@@ -63,7 +63,7 @@ jobs:
 
       - name: Validate plugin structure
         if: steps.changed-files.outputs.has_changes == 'true'
-        uses: anthropics/claude-code-action@098e6be5fa94fd7f5b98b1f1a9b874cb9269e583 # v1.0.29
+        uses: anthropics/claude-code-action@1b8ee3b94104046d71fde52ec3557651ad8c0d71 # v1.0.29
         id: validate
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}

--- a/.github/workflows/semantic-labeler.yml
+++ b/.github/workflows/semantic-labeler.yml
@@ -36,7 +36,7 @@ jobs:
           fetch-depth: 1
 
       - name: Label issue with Claude
-        uses: anthropics/claude-code-action@098e6be5fa94fd7f5b98b1f1a9b874cb9269e583 # v1.0.29
+        uses: anthropics/claude-code-action@1b8ee3b94104046d71fde52ec3557651ad8c0d71 # v1.0.29
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           prompt: |
@@ -118,7 +118,7 @@ jobs:
           fetch-depth: 1
 
       - name: Label PR with Claude
-        uses: anthropics/claude-code-action@098e6be5fa94fd7f5b98b1f1a9b874cb9269e583 # v1.0.29
+        uses: anthropics/claude-code-action@1b8ee3b94104046d71fde52ec3557651ad8c0d71 # v1.0.29
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           prompt: |

--- a/.github/workflows/sync-labels.yml
+++ b/.github/workflows/sync-labels.yml
@@ -15,7 +15,7 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Sync labels
-        uses: EndBug/label-sync@7753e99e1e64188c24d7deede343c5a63e7c0d39 # v2.3.3
+        uses: EndBug/label-sync@52074158190acb45f3077f9099fea818aa43f97a # v2.3.3
         with:
           config-file: .github/labels.json
           delete-other-labels: false

--- a/.github/workflows/validate-workflows.yml
+++ b/.github/workflows/validate-workflows.yml
@@ -27,7 +27,7 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Run actionlint
-        uses: reviewdog/action-actionlint@c50cc86378c76976bc8d9c67e0f12327f85c323f # v1.69.1
+        uses: reviewdog/action-actionlint@83e4ed25b168066ad8f62f5afbb29ebd8641d982 # v1.69.1
         with:
           fail_on_error: true
           reporter: github-pr-review


### PR DESCRIPTION
## Summary

Update GitHub Action references to use commit SHAs instead of annotated tag object SHAs for consistency with other projects in the organization.

## Type of Change

- [x] Chore/maintenance

## Changes Made

- Updated `anthropics/claude-code-action@v1.0.29` SHA from `098e6be5...` to `1b8ee3b9...`
- Updated `EndBug/label-sync@v2.3.3` SHA from `7753e99e...` to `52074158...`
- Updated `reviewdog/action-actionlint@v1.69.1` SHA from `c50cc863...` to `83e4ed25...`

Both SHA types resolve to the same code, but commit SHAs are the standard convention.

## Testing

- [x] Ran `markdownlint "**/*.md"` with no errors
- N/A for plugin testing - this only affects workflow SHA references

## Checklist

- [x] My changes follow the existing code style
- [x] I have tested my changes locally

---

🤖 Generated with [Claude Code](https://claude.ai/code)