### PR TITLE
chore: replace pinned actions with on-demand tools

### DIFF
--- a/.github/workflows/claude-pr-review.yml
+++ b/.github/workflows/claude-pr-review.yml
@@ -33,14 +33,6 @@ jobs:
         with:
           fetch-depth: 1
 
-      - name: Setup Node.js
-        uses: actions/setup-node@395ad3262231945c25e8478fd5baf05154b1d79f # v6.1.0
-        with:
-          node-version: "20"
-
-      - name: Install markdownlint-cli
-        run: npm install -g markdownlint-cli
-
       - name: Review PR with Claude
         uses: anthropics/claude-code-action@1b8ee3b94104046d71fde52ec3557651ad8c0d71 # v1.0.29
         with:
@@ -56,7 +48,7 @@ jobs:
 
             ## Instructions
             1. Get the PR diff to understand what changed
-            2. If any `.md` files were changed, run `markdownlint --config .markdownlint.json <files>` to check for style issues
+            2. If any `.md` files were changed, run `npx markdownlint-cli2 <files>` to check for style issues
             3. Review the changes against the criteria below
             4. Post a summary comment with your findings
 
@@ -75,7 +67,7 @@ jobs:
             - New terms should fit the transformation use case
 
             ### Markdown Quality (run markdownlint)
-            Run `markdownlint --config .markdownlint.json` on changed `.md` files. Key rules enforced:
+            Run `npx markdownlint-cli2` on changed `.md` files. Key rules enforced:
             - ATX-style headers (`#` not underlines)
             - Dash-style lists (`-` not `*` or `+`)
             - 2-space indentation for nested lists
@@ -101,4 +93,4 @@ jobs:
             Be constructive and helpful. Focus on significant issues, not nitpicks.
             If the PR looks good, say so briefly - don't invent problems.
           claude_args: |
-            --allowedTools "Bash(gh pr:*),Bash(markdownlint:*),Read,Glob,Grep,mcp__github_inline_comment__create_inline_comment"
+            --allowedTools "Bash(gh pr:*),Bash(npx markdownlint-cli2:*),Read,Glob,Grep,mcp__github_inline_comment__create_inline_comment"

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -51,11 +51,6 @@ jobs:
         with:
           fetch-depth: 1
 
-      - name: Setup Node.js
-        uses: actions/setup-node@395ad3262231945c25e8478fd5baf05154b1d79f # v6.1.0
-        with:
-          node-version: "20"
-
       - name: Run Claude Code
         id: claude
         uses: anthropics/claude-code-action@1b8ee3b94104046d71fde52ec3557651ad8c0d71 # v1.0.29

--- a/.github/workflows/shellcheck.yml
+++ b/.github/workflows/shellcheck.yml
@@ -29,8 +29,6 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
+      # ShellCheck is pre-installed on ubuntu-latest runners
       - name: Run ShellCheck
-        uses: ludeeus/action-shellcheck@00cae500b08a931fb5698e11e79bfbd38e612a38 # v2.0.0
-        with:
-          scandir: './plugins'
-          severity: warning
+        run: find ./plugins -type f -name "*.sh" -exec shellcheck --severity=warning {} +


### PR DESCRIPTION
## Summary

Replace external action dependencies with pre-installed tools or on-demand package execution to reduce maintenance burden from SHA pinning.

## Type of Change

- [x] Chore/maintenance

## Changes Made

- **shellcheck.yml**: Replace `ludeeus/action-shellcheck` action with direct `shellcheck` command (pre-installed on ubuntu-latest runners)
- **claude-pr-review.yml**: Remove `actions/setup-node` and `npm install -g markdownlint-cli`, use `npx markdownlint-cli2` instead
- **claude.yml**: Remove `actions/setup-node` step (Claude Code Action uses Bun internally, not Node.js)

### Dependencies Eliminated

| Workflow | Removed Action | Replacement |
|----------|----------------|-------------|
| `shellcheck.yml` | `ludeeus/action-shellcheck` | Pre-installed `shellcheck` binary |
| `claude-pr-review.yml` | `actions/setup-node` | Not needed (Claude uses Bun) |
| `claude-pr-review.yml` | `npm install -g markdownlint-cli` | `npx markdownlint-cli2` |
| `claude.yml` | `actions/setup-node` | Not needed (Claude uses Bun) |

## Testing

- [x] Ran `markdownlint "**/*.md"` with no errors
- [x] Ran `actionlint` to validate workflow syntax
- [x] Ran `yamllint` on changed workflow files

## Checklist

- [x] My changes follow the existing code style
- [x] I have tested my changes locally
- [x] I have updated documentation (if applicable)

---

🤖 Generated with [Claude Code](https://claude.ai/code)